### PR TITLE
Eliminar links para calificar a un profesor

### DIFF
--- a/frontend/assets/css/index.css
+++ b/frontend/assets/css/index.css
@@ -49,17 +49,14 @@
 
 .calificar-link {
     color: #007bff; 
-    text-decoration: none;
     font-weight: bold;
     padding: 5px 10px;
     border-radius: 4px;
-    transition: background-color 0.3s, color 0.3s;
 }
 
 .calificar-link:hover {
     background-color: #e9ecef;
     color: #0056b3;
-    text-decoration: underline;
 }
 
 .calificar-link:active {

--- a/frontend/assets/css/index.css
+++ b/frontend/assets/css/index.css
@@ -52,6 +52,7 @@
     font-weight: bold;
     padding: 5px 10px;
     border-radius: 4px;
+    text-decoration: none;
 }
 
 .calificar-link:hover {

--- a/frontend/html/index.html
+++ b/frontend/html/index.html
@@ -34,10 +34,8 @@
             <table class="profesor-table">
                 <thead>
                     <tr>
-                        <th>Apellidos</th>
-                        <th>Nombres</th>
+                        <th>Nombre del profesor</th>
                         <th>Promedio</th>
-                        <th></th>
                     </tr>
                 </thead>
                 <tbody>

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -58,16 +58,12 @@ const loadProfesoresTable = function(profesores){
         const nombreProfesorTd = document.createElement('td');
 
         const linkParaCalificar = document.createElement('a');
-        linkParaCalificar.innerHTML = profesor.apellidos;
+        linkParaCalificar.innerHTML = profesor.apellidos + ' ' + profesor.nombres;
         linkParaCalificar.classList.add('calificar-link')
         linkParaCalificar.href = 'recomendaciones.html?profesor_id=' + profesor.id + 
         '&profesor_apellidos=' + profesor.apellidos.replace(' ', '_') + 
         '&profesor_nombres=' + profesor.nombres.replace(' ', '_');
         nombreProfesorTd.appendChild(linkParaCalificar);
-        
-        const nombresSpan = document.createElement('span');
-        nombresSpan.textContent = ', ' + profesor.nombres;
-        nombreProfesorTd.appendChild(nombresSpan);
         
         row.appendChild(nombreProfesorTd);
 

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -55,28 +55,25 @@ const loadProfesoresTable = function(profesores){
     profesores.forEach(profesor => {
         const row = document.createElement('tr');
         
-        const apellidosTd = document.createElement('td');
-        apellidosTd.textContent = profesor.apellidos;
-        row.appendChild(apellidosTd);
+        const nombreProfesorTd = document.createElement('td');
 
-        const nombresTd = document.createElement('td');
-        nombresTd.textContent = profesor.nombres;
-        row.appendChild(nombresTd);
+        const linkParaCalificar = document.createElement('a');
+        linkParaCalificar.innerHTML = profesor.apellidos;
+        linkParaCalificar.classList.add('calificar-link')
+        linkParaCalificar.href = 'recomendaciones.html?profesor_id=' + profesor.id + 
+        '&profesor_apellidos=' + profesor.apellidos.replace(' ', '_') + 
+        '&profesor_nombres=' + profesor.nombres.replace(' ', '_');
+        nombreProfesorTd.appendChild(linkParaCalificar);
+        
+        const nombresSpan = document.createElement('span');
+        nombresSpan.textContent = ', ' + profesor.nombres;
+        nombreProfesorTd.appendChild(nombresSpan);
+        
+        row.appendChild(nombreProfesorTd);
 
         const promedioTd = document.createElement('td');
         promedioTd.textContent = profesor.promedio;
         row.appendChild(promedioTd);
-
-        const calificarTd = document.createElement('td');
-        const link = document.createElement('a');
-        link.href = "recomendaciones.html?profesor_id=" + profesor.id + 
-        "&profesor_apellidos=" + profesor.apellidos.replace(' ', '_') + 
-        "&profesor_nombres=" + profesor.nombres.replace(' ', '_');
-
-        link.textContent = 'Calificar';
-        link.classList.add('calificar-link');
-        calificarTd.appendChild(link);
-        row.appendChild(calificarTd);
 
         tableBody.appendChild(row);
     });


### PR DESCRIPTION
Quité la columna, en la tabla de profesores del index, que contiene anchor tags con el texto "calificar", cada uno de estos anchors apuntaba a las reviews de un profesor. Además, creé una columna, en la tabla previamente mencionada, que combina los apellidos y los nombres de un profesor, esto en lugar de tener una columna para los apellidos y una para los nombres. Por último, convertí la parte de los apellidos en un anchor tag que apunta a las reviews del profesor en cuestión.
 